### PR TITLE
make log_irreversible public

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -4685,6 +4685,10 @@ uint32_t controller::if_irreversible_block_num() const {
    return block_header::num_from_id(my->if_irreversible_block_id);
 }
 
+void controller::log_irreversible() {
+   my->log_irreversible();
+}
+
 uint32_t controller::last_irreversible_block_num() const {
    return my->fork_db_root_block_num();
 }

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -264,6 +264,8 @@ namespace eosio::chain {
          void set_if_irreversible_block_id(const block_id_type& id);
          uint32_t if_irreversible_block_num() const;
 
+         void log_irreversible();
+
          uint32_t last_irreversible_block_num() const;
          block_id_type last_irreversible_block_id() const;
          time_point last_irreversible_block_time() const;


### PR DESCRIPTION
This PR exposes `controller_impl::log_irreversilbe()` to `controller` class so it can be publicly available. 