### PR TITLE
Add leap-util option to replace producer keys

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5625,16 +5625,6 @@ void controller::replace_producer_keys( const public_key_type& key ) {
       gp.proposed_schedule.producers.clear();
    });
 
-   auto& authorization = get_mutable_authorization_manager();
-   auto permission = authorization.find_permission({chain::config::system_account_name, chain::config::active_name});
-   EOS_ASSERT( permission, permission_query_exception, "Unable to find eosio account");
-
-   authority auth(key);
-   mutable_db().modify( *permission, [&](permission_object& po) {
-      po.auth = auth;
-      po.last_updated = fc::time_point::now();
-   });
-
    my->replace_producer_keys(key);
 }
 
@@ -5646,6 +5636,7 @@ void controller::replace_account_keys( name account, name permission, const publ
    int64_t old_size = (int64_t)(chain::config::billable_size_v<permission_object> + perm->auth.get_billable_size());
    mutable_db().modify(*perm, [&](auto& p) {
       p.auth = authority(key);
+      p.last_updated = fc::time_point::now();
    });
    int64_t new_size = (int64_t)(chain::config::billable_size_v<permission_object> + perm->auth.get_billable_size());
    rlm.add_pending_ram_usage(account, new_size - old_size, false); // false for doing dm logging

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1002,6 +1002,8 @@ struct controller_impl {
                }
             },
             [](const block_state_ptr&) {
+               elog("replace_producer_keys not implemented for instant-finality");
+               EOS_ASSERT(false, producer_exception, "replace_producer_keys not implemented for instant-finality");
                // TODO IF: add instant-finality implementation, will need to replace finalizers as well
             }
          });

--- a/programs/leap-util/actions/chain.cpp
+++ b/programs/leap-util/actions/chain.cpp
@@ -11,6 +11,7 @@
 #include <eosio/chain/block_log.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/chainbase_environment.hpp>
+#include <eosio/chain/controller.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -22,6 +23,7 @@ using namespace eosio::chain;
 void chain_actions::setup(CLI::App& app) {
    auto* sub = app.add_subcommand("chain-state", "chain utility");
    sub->add_option("--state-dir", opt->sstate_state_dir, "The location of the state directory (absolute path or relative to the current directory)")->capture_default_str();
+   sub->add_option("--blocks-dir", opt->blocks_dir, "The location of the blocks directory (absolute path or relative to the current directory)")->capture_default_str();
    sub->require_subcommand();
    sub->fallthrough();
 
@@ -41,6 +43,18 @@ void chain_actions::setup(CLI::App& app) {
       // properly return err code in main
       if(rc) throw(CLI::RuntimeError(rc));
    });
+
+   // -- replace-producer-keys
+   build = sub->add_subcommand("replace-producer-keys", "Replace the producer keys and change chain id");
+   build->add_option("--db-size", opt->db_size, "Maximum size (in MiB) of the chain state database")->capture_default_str();
+   auto* sub_opt = build->add_option("--key", opt->producer_key, "Public key to assign to all producers")->capture_default_str();
+   sub_opt->required();
+   build->callback([&]() {
+      int rc = run_subcommand_replace_producer_keys();
+      // properly return err code in main
+      if (rc) throw(CLI::RuntimeError(rc));
+   });
+
 }
 
 int chain_actions::run_subcommand_build() {
@@ -59,22 +73,28 @@ int chain_actions::run_subcommand_build() {
    return 0;
 }
 
-int chain_actions::run_subcommand_sstate() {
-   std::filesystem::path state_dir = "";
+template <typename SubcommandOptions>
+inline std::filesystem::path get_state_dir(std::shared_ptr<SubcommandOptions> opt) {
+   std::filesystem::path state_dir;
 
    // default state dir, if none specified
    if(opt->sstate_state_dir.empty()) {
       auto root = fc::app_path();
       auto default_data_dir = root / "eosio" / "nodeos" / "data" ;
       state_dir  = default_data_dir / config::default_state_dir_name;
-   }
-   else {
+   } else {
       // adjust if path relative
       state_dir = opt->sstate_state_dir;
       if(state_dir.is_relative()) {
          state_dir = std::filesystem::current_path() / state_dir;
       }
    }
+
+   return state_dir;
+}
+
+int chain_actions::run_subcommand_sstate() {
+   std::filesystem::path state_dir = get_state_dir(opt);
 
    auto shared_mem_path = state_dir / "shared_memory.bin";
 
@@ -103,5 +123,67 @@ int chain_actions::run_subcommand_sstate() {
    }
 
    std::cout << "Database state is clean" << std::endl;
+   return 0;
+}
+
+int chain_actions::run_subcommand_replace_producer_keys() {
+   std::filesystem::path state_dir = get_state_dir(opt);
+
+   auto shared_mem_path = state_dir / "shared_memory.bin";
+
+   if(!std::filesystem::exists(shared_mem_path)) {
+      std::cerr << "Unable to read database status: file not found: " << shared_mem_path << std::endl;
+      return -1;
+   }
+
+   if (opt->blocks_dir.empty()) {
+      std::cerr << "--blocks-dir required " << std::endl;
+      return -1;
+   }
+
+   public_key_type producer_key(opt->producer_key);
+
+   // setup controller
+   fc::temp_directory dir;
+   const auto& temp_dir = dir.path();
+   std::filesystem::path finalizers_dir = temp_dir / "finalizers";
+   std::unique_ptr<controller> control;
+   controller::config cfg;
+   cfg.blocks_dir = opt->blocks_dir;
+   cfg.finalizers_dir = finalizers_dir;
+   cfg.state_dir  = state_dir;
+   cfg.state_size = opt->db_size * 1024 * 1024;
+   cfg.eosvmoc_tierup = wasm_interface::vm_oc_enable::oc_none; // wasm not used, no use to fire up oc
+   protocol_feature_set pfs = initialize_protocol_features( std::filesystem::path("protocol_features"), false );
+
+   try {
+      auto chain_id = controller::extract_chain_id_from_db( state_dir );
+      if (!chain_id) {
+         std::cerr << "Unable to extract chain id from state: " << state_dir << std::endl;
+         return -1;
+      }
+
+      auto check_shutdown = []() { return false; };
+      auto shutdown = []() { throw; };
+
+      control.reset(new controller(cfg, std::move(pfs), *chain_id));
+      control->add_indices();
+      control->startup(shutdown, check_shutdown);
+
+      if (!opt->producer_key.empty()) {
+         control->replace_producer_keys(producer_key);
+      }
+   } catch(const database_guard_exception& e) {
+      std::cerr << "Database is not configured to have enough storage to handle provided snapshot, please increase storage and try again" << std::endl;
+      control.reset();
+      return -1;
+   } catch (const fc::exception& ex) {
+      std::cerr << "Exception: " << ex.to_detail_string() << std::endl;
+      return -1;
+   } catch (const std::exception& ex) {
+      std::cerr << "STD Exception: " << ex.what() << std::endl;
+      return -1;
+   }
+
    return 0;
 }

--- a/programs/leap-util/actions/chain.hpp
+++ b/programs/leap-util/actions/chain.hpp
@@ -6,7 +6,7 @@ struct chain_options {
    std::string sstate_state_dir;
    std::string blocks_dir;
    std::string producer_key;
-   uint64_t db_size = 65536ull;
+   uint64_t db_size_mb = 65536ull;
 };
 
 class chain_actions : public sub_command<chain_options> {

--- a/programs/leap-util/actions/chain.hpp
+++ b/programs/leap-util/actions/chain.hpp
@@ -2,8 +2,11 @@
 
 struct chain_options {
    bool build_just_print = false;
-   std::string build_output_file = "";
-   std::string sstate_state_dir = "";
+   std::string build_output_file;
+   std::string sstate_state_dir;
+   std::string blocks_dir;
+   std::string producer_key;
+   uint64_t db_size = 65536ull;
 };
 
 class chain_actions : public sub_command<chain_options> {
@@ -14,4 +17,5 @@ public:
    // callbacks
    int run_subcommand_build();
    int run_subcommand_sstate();
+   int run_subcommand_replace_producer_keys();
 };


### PR DESCRIPTION
Useful for setting up local testnet from public network.

Example:
```
./leap-util chain-state replace-producer-keys --state-dir data/state --blocks-dir data/blocks --key EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
```

Note: Currently only works pre-Instant-Finality

Replaces the legacy active producer schedule.
